### PR TITLE
change imports for dynamic characterization

### DIFF
--- a/temporal/6 - Dynamic characterization.ipynb
+++ b/temporal/6 - Dynamic characterization.ipynb
@@ -168,7 +168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bw_timex.dynamic_characterization import characterize_ch4\n",
+    "from dynamic_characterization.timex.radiative_forcing import characterize_ch4\n",
     "\n",
     "characterize_ch4?"
    ]
@@ -524,7 +524,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bw_timex.dynamic_characterization import characterize_n2o, characterize_co2\n",
+    "from dynamic_characterization.timex.radiative_forcing import characterize_n2o, characterize_co2\n",
     "\n",
     "demand = {(\"test\", \"A\"): 1}\n",
     "gwp = (\"GWP\", \"example\")\n",
@@ -705,9 +705,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:bw25update]",
+   "display_name": "bw25",
    "language": "python",
-   "name": "conda-env-bw25update-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -719,7 +719,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The dynamic characterization functions from bw_timex are now refactored to a separate repo/package (https://github.com/brightway-lca/dynamic_characterization), breaking the old imports in the example notebook on dynamic characterization. 

dynamic_characterization is now a mandatory dependency of bw_timex, so depending on the environment this notebook is meant for, one would either have to update the version of timex or additionally install the dynamic_characterization package.
